### PR TITLE
유준봉 9/27 신청합니다

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a repository of the study "DL Compiler and Hardware". The goal of this s
 | 8/16  | -      | -                                                                                       | -     | #4      | -    |
 | 8/30  |  김정현 | FACT: FFN-Attention Co-optimized Transformer Architecture with Eager Correlation Prediction | - | #5 | -   |
 | 9/13  | 이현승 | V10: Hardware-Assisted NPU Multi-tenancy for Improved Resource Utilization and Fairness | -     | #6      | -    |
-| 9/27  | -      | -                                                                                       | -     | #7      | -    |
+| 9/27  |  유준봉  | GROW: A Row-Stationary Sparse-Dense GEMM Accelerator for Memory-Efficient Graph Convolutional Neural Networks | -     | #7      | -    |
 | 10/11 | -      | -                                                                                       | -     | #8      | -    |
 | 10/25 | -      | -                                                                                       | -     | #9      | -    |
 | 11/08 | -      | -                                                                                       | -     | #10     | -    |


### PR DESCRIPTION
9/27일 발표를 신청합니다
카이스트에서 쓰고 HPCA 2023 에서 발표되었던 GROW: A Row-Stationary Sparse-Dense GEMM Accelerator for Memory-Efficient Graph Convolutional Neural Networks 논문입니다
